### PR TITLE
linux: Add Firefox config directory from XDG Base Directory Specification

### DIFF
--- a/scripts/git-pull-chrome-only.sh
+++ b/scripts/git-pull-chrome-only.sh
@@ -161,15 +161,20 @@ case "$(uname -s)" in
         profile_containers+=("$HOME/Library/Application Support/Firefox/Profiles")
         ;;
     Linux)
+        xdg_config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+        if [[ "$xdg_config_home" != /* ]]; then
+            xdg_config_home="$HOME/.config"
+        fi
+
         firefox_roots+=(
             "$HOME/.mozilla/firefox"
-            "${XDG_CONFIG_HOME:-$HOME/.config}/mozilla/firefox"
+            "$xdg_config_home/mozilla/firefox"
             "$HOME/snap/firefox/common/.mozilla/firefox"
             "$HOME/.var/app/org.mozilla.firefox/.mozilla/firefox"
         )
         profile_containers+=(
             "$HOME/.mozilla/firefox"
-            "${XDG_CONFIG_HOME:-$HOME/.config}/mozilla/firefox"
+            "$xdg_config_home/mozilla/firefox"
             "$HOME/snap/firefox/common/.mozilla/firefox"
             "$HOME/.var/app/org.mozilla.firefox/.mozilla/firefox"
         )

--- a/scripts/git-pull-chrome-only.sh
+++ b/scripts/git-pull-chrome-only.sh
@@ -163,13 +163,13 @@ case "$(uname -s)" in
     Linux)
         firefox_roots+=(
             "$HOME/.mozilla/firefox"
-            "$HOME/.config/mozilla/firefox"
+            "${XDG_CONFIG_HOME:-$HOME/.config}/mozilla/firefox"
             "$HOME/snap/firefox/common/.mozilla/firefox"
             "$HOME/.var/app/org.mozilla.firefox/.mozilla/firefox"
         )
         profile_containers+=(
             "$HOME/.mozilla/firefox"
-            "$HOME/.config/mozilla/firefox"
+            "${XDG_CONFIG_HOME:-$HOME/.config}/mozilla/firefox"
             "$HOME/snap/firefox/common/.mozilla/firefox"
             "$HOME/.var/app/org.mozilla.firefox/.mozilla/firefox"
         )

--- a/scripts/git-pull-chrome-only.sh
+++ b/scripts/git-pull-chrome-only.sh
@@ -163,11 +163,13 @@ case "$(uname -s)" in
     Linux)
         firefox_roots+=(
             "$HOME/.mozilla/firefox"
+            "$HOME/.config/mozilla/firefox"
             "$HOME/snap/firefox/common/.mozilla/firefox"
             "$HOME/.var/app/org.mozilla.firefox/.mozilla/firefox"
         )
         profile_containers+=(
             "$HOME/.mozilla/firefox"
+            "$HOME/.config/mozilla/firefox"
             "$HOME/snap/firefox/common/.mozilla/firefox"
             "$HOME/.var/app/org.mozilla.firefox/.mozilla/firefox"
         )


### PR DESCRIPTION
Firefox started to support [freedesktop.org XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/) from version 147. New installs now put default config `~/.config/mozilla/firefox` instead of `~/.mozilla/firefox`. Newer versions still check `~/.mozilla/firefox` but they prefer `~/.config/mozilla/firefox`. So I added the new config directory among the others. I tested for my system and it found all of my firefox profiles.

